### PR TITLE
Finish client side interpreter prototype

### DIFF
--- a/html/solve.html
+++ b/html/solve.html
@@ -46,6 +46,10 @@
           <li class="nav-item">
             <a class="nav-link" id="analysis-tab" data-toggle="tab" href="#analysis" role="tab" aria-controls="analysis" aria-selected="false">Analysis</a>
           </li>
+          <div>
+            <button type="button" id="run-button" class="btn btn-success" onclick="executeCode()">Run</button>
+            <button type="button" id="stop-button" class="btn btn-danger" onclick="stopRunningCode()" hidden>Stop</button>
+          </div>
         </ul>
       </div>
       <div class="card-body">

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -1,21 +1,38 @@
 const SAMPLE_CODE       = 'function myScript(){return 100;}\n';
 const CODE_AREA_ID      = 'code-area';
 const CODE_OUTPUT_ID    = 'code-output';
+const RUN_BUTTON_ID     = 'run-button';
+const STOP_BUTTON_ID    = 'stop-button';
+const HIDDEN_ATTRIBUTE  = 'hidden';
 const NEWLINE           = '\n';
 
 var codeMirror;
 var outputArea;
+var runButton;
+var stopButton;
+var keepRunningCode;
 
 window.addEventListener('load', function() {
+  setupCodeMirror();
+  setupElements();
+  runStaticAnalysis(myCodeMirror.getValue());
+});
+
+function setupCodeMirror() {
   codeMirror = CodeMirror(document.getElementById(CODE_AREA_ID), {
     value: 'function myScript(){return 100;}\n',
     mode:  'javascript',
     lineNumbers: true,
   });
+}
 
-  outputArea = document.getElementById(CODE_OUTPUT_ID);
-  runStaticAnalysis(myCodeMirror.getValue());
 });
+
+function setupElements() {
+  outputArea    = document.getElementById(CODE_OUTPUT_ID);
+  runButton     = document.getElementById(RUN_BUTTON_ID);
+  stopButton    = document.getElementById(STOP_BUTTON_ID);
+}
 
 function overrideFunctions(interpreter, scope) {
   var alertOverride = function(text) {
@@ -28,9 +45,40 @@ function overrideFunctions(interpreter, scope) {
 
 function executeCode() {
   let code      = codeMirror.getValue();
-  myInterpreter = new Interpreter(code, overrideFunctions);
+  interpreter = new Interpreter(code, overrideFunctions);
 
-  myInterpreter.run();
+  startRunningCode(interpreter);
+}
+
+function updateButtons() {
+  if (keepRunningCode) {
+    runButton.setAttribute(HIDDEN_ATTRIBUTE, true);
+    stopButton.removeAttribute(HIDDEN_ATTRIBUTE);
+  } else {
+    stopButton.setAttribute(HIDDEN_ATTRIBUTE, true);
+    runButton.removeAttribute(HIDDEN_ATTRIBUTE);
+  }
+}
+
+function startRunningCode(interpreter) {
+  outputArea.innerHTML  = '';
+  keepRunningCode       = true;
+  updateButtons();
+
+  function nextStep() {
+    if (keepRunningCode && interpreter.step()) {
+      setTimeout(nextStep, 0);
+    } else {
+      keepRunningCode = false;
+      updateButtons();
+    }
+  }
+  nextStep();
+}
+
+function stopRunningCode() {
+  keepRunningCode = false;
+  updateButtons();
 }
 
 function runStaticAnalysis(code) {

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -44,10 +44,19 @@ function overrideFunctions(interpreter, scope) {
 }
 
 function executeCode() {
-  let code      = codeMirror.getValue();
-  interpreter = new Interpreter(code, overrideFunctions);
+  outputArea.innerHTML  = '';
+  keepRunningCode       = true;
+  updateButtons();
 
-  startRunningCode(interpreter);
+  try {
+    let code    = codeMirror.getValue();
+    interpreter = new Interpreter(code, overrideFunctions);
+    startRunningCode(interpreter); 
+  } catch (error) {
+    outputArea.innerHTML += error + NEWLINE;
+    keepRunningCode = false;
+    updateButtons();
+  }
 }
 
 function updateButtons() {
@@ -61,10 +70,6 @@ function updateButtons() {
 }
 
 function startRunningCode(interpreter) {
-  outputArea.innerHTML  = '';
-  keepRunningCode       = true;
-  updateButtons();
-
   function nextStep() {
     if (keepRunningCode && interpreter.step()) {
       setTimeout(nextStep, 0);

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -18,6 +18,10 @@ window.addEventListener('load', function() {
   runStaticAnalysis(myCodeMirror.getValue());
 });
 
+/**
+ * Sets up text editor.
+ * Further modification to the text editor should be done here.
+ **/
 function setupCodeMirror() {
   codeMirror = CodeMirror(document.getElementById(CODE_AREA_ID), {
     value: 'function myScript(){return 100;}\n',
@@ -34,6 +38,13 @@ function setupElements() {
   stopButton    = document.getElementById(STOP_BUTTON_ID);
 }
 
+/**
+* Function to override functions call inside the sandbox interpreter.
+* This function serves as an interface between the browser and the sandbox.
+* 
+* By overriding alert() in the sandbox for example, we can modify alert()
+* so that its can be displayed on the GUI, outside of the sandbox.
+**/
 function overrideFunctions(interpreter, scope) {
   var alertOverride = function(text) {
     outputArea.innerHTML += text + NEWLINE;
@@ -53,6 +64,15 @@ function overrideFunctions(interpreter, scope) {
     interpreter.createNativeFunction(assertOverride));
 }
 
+/**
+* Wrapper function around startRunningCode.
+* This function mostly serves to try to catch any error encountered
+* when trying to interpret invalid JavaScript code,
+* preventing the interpreter from failing silently.
+*
+* Should an invalid JavaScript code be encountered, it will be
+* displayed to the user.
+**/
 function executeCode() {
   outputArea.innerHTML  = '';
   keepRunningCode       = true;
@@ -79,6 +99,12 @@ function updateButtons() {
   }
 }
 
+/**
+* Runs the interpreter step by step until we are finished.
+* Utilizes setTimeout() to allow other tasks to run too
+* and prevents the application from bricking in cases such as
+* infinite loops.
+**/
 function startRunningCode(interpreter) {
   function nextStep() {
     if (keepRunningCode && interpreter.step()) {

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -6,11 +6,11 @@ const STOP_BUTTON_ID    = 'stop-button';
 const HIDDEN_ATTRIBUTE  = 'hidden';
 const NEWLINE           = '\n';
 
-var codeMirror;
-var outputArea;
-var runButton;
-var stopButton;
-var keepRunningCode;
+let codeMirror;
+let outputArea;
+let runButton;
+let stopButton;
+let keepRunningCode;
 
 window.addEventListener('load', function() {
   setupCodeMirror();
@@ -46,11 +46,11 @@ function setupElements() {
 * so that its can be displayed on the GUI, outside of the sandbox.
 **/
 function overrideFunctions(interpreter, scope) {
-  var alertOverride = function(text) {
+  let alertOverride = function(text) {
     outputArea.innerHTML += text + NEWLINE;
   };
 
-  var assertOverride = function(isTrue, message) {
+  let assertOverride = function(isTrue, message) {
     if (!isTrue) {
       outputArea.innerHTML += message || "Assertion failed";
       keepRunningCode = false;

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -39,12 +39,12 @@ function setupElements() {
 }
 
 /**
-* Function to override functions call inside the sandbox interpreter.
-* This function serves as an interface between the browser and the sandbox.
-* 
-* By overriding alert() in the sandbox for example, we can modify alert()
-* so that its can be displayed on the GUI, outside of the sandbox.
-**/
+ * Function to override functions call inside the sandbox interpreter.
+ * This function serves as an interface between the browser and the sandbox.
+ * 
+ * By overriding alert() in the sandbox for example, we can modify alert()
+ * so that its can be displayed on the GUI, outside of the sandbox.
+ **/
 function overrideFunctions(interpreter, scope) {
   let alertOverride = function(text) {
     outputArea.innerHTML += text + NEWLINE;
@@ -65,14 +65,14 @@ function overrideFunctions(interpreter, scope) {
 }
 
 /**
-* Wrapper function around startRunningCode.
-* This function mostly serves to try to catch any error encountered
-* when trying to interpret invalid JavaScript code,
-* preventing the interpreter from failing silently.
-*
-* Should an invalid JavaScript code be encountered, it will be
-* displayed to the user.
-**/
+ * Wrapper function around startRunningCode.
+ * This function mostly serves to try to catch any syntax error 
+ * encountered when trying to parse invalid JavaScript code,
+ * preventing the interpreter from failing silently.
+ *
+ * Should an invalid JavaScript code be encountered, it will be
+ * displayed to the user.
+ **/
 function executeCode() {
   outputArea.innerHTML  = '';
   keepRunningCode       = true;
@@ -100,14 +100,18 @@ function updateButtons() {
 }
 
 /**
-* Runs the interpreter step by step until we are finished.
-* Utilizes setTimeout() to allow other tasks to run too
-* and prevents the application from bricking in cases such as
-* infinite loops.
-**/
+ * Runs the interpreter step by step until we are finished.
+ * Utilizes setTimeout() to allow other tasks to run too
+ * and prevents the application from bricking in cases such as
+ * infinite loops.
+ *
+ * Uses tryStep() to handle undefined reference error and
+ * relay the error back to the user. Note that this error
+ * is different than the one handled by executeCode().
+ **/
 function startRunningCode(interpreter) {
   function nextStep() {
-    if (keepRunningCode && interpreter.step()) {
+    if (keepRunningCode && tryStep(interpreter)) {
       setTimeout(nextStep, 0);
     } else {
       keepRunningCode = false;
@@ -115,6 +119,15 @@ function startRunningCode(interpreter) {
     }
   }
   nextStep();
+}
+
+function tryStep(interpreter) {
+  try {
+    return interpreter.step();
+  } catch(error) {   
+    outputArea.innerHTML += error + NEWLINE;
+    return false;
+  }
 }
 
 function stopRunningCode() {

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -15,7 +15,6 @@ let keepRunningCode;
 window.addEventListener('load', function() {
   setupCodeMirror();
   setupElements();
-  runStaticAnalysis(myCodeMirror.getValue());
 });
 
 /**
@@ -24,13 +23,15 @@ window.addEventListener('load', function() {
  **/
 function setupCodeMirror() {
   codeMirror = CodeMirror(document.getElementById(CODE_AREA_ID), {
-    value: 'function myScript(){return 100;}\n',
+    value: SAMPLE_CODE,
     mode:  'javascript',
     lineNumbers: true,
   });
-}
 
-});
+  codeMirror.on('change', function() {
+    runStaticAnalysis(codeMirror.getValue());
+  });
+}
 
 function setupElements() {
   outputArea    = document.getElementById(CODE_OUTPUT_ID);

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -1,14 +1,37 @@
-const sampleCode = 'function myScript(){return 100;}\n';
+const SAMPLE_CODE       = 'function myScript(){return 100;}\n';
+const CODE_AREA_ID      = 'code-area';
+const CODE_OUTPUT_ID    = 'code-output';
+const NEWLINE           = '\n';
+
+var codeMirror;
+var outputArea;
 
 window.addEventListener('load', function() {
-  const myCodeMirror = CodeMirror(document.getElementById('code-area'), {
-    value: sampleCode,
-    mode: 'javascript',
-    lineNumbers: true
+  codeMirror = CodeMirror(document.getElementById(CODE_AREA_ID), {
+    value: 'function myScript(){return 100;}\n',
+    mode:  'javascript',
+    lineNumbers: true,
   });
 
+  outputArea = document.getElementById(CODE_OUTPUT_ID);
   runStaticAnalysis(myCodeMirror.getValue());
 });
+
+function overrideFunctions(interpreter, scope) {
+  var alertOverride = function(text) {
+    outputArea.innerHTML += text + NEWLINE;
+  };
+
+  interpreter.setProperty(scope, 'alert', 
+    interpreter.createNativeFunction(alertOverride));
+}
+
+function executeCode() {
+  let code      = codeMirror.getValue();
+  myInterpreter = new Interpreter(code, overrideFunctions);
+
+  myInterpreter.run();
+}
 
 function runStaticAnalysis(code) {
   let totalComplexity = 0;

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -39,8 +39,18 @@ function overrideFunctions(interpreter, scope) {
     outputArea.innerHTML += text + NEWLINE;
   };
 
+  var assertOverride = function(isTrue, message) {
+    if (!isTrue) {
+      outputArea.innerHTML += message || "Assertion failed";
+      keepRunningCode = false;
+      updateButtons();
+    }
+  }
+
   interpreter.setProperty(scope, 'alert', 
     interpreter.createNativeFunction(alertOverride));
+  interpreter.setProperty(scope, 'assert', 
+    interpreter.createNativeFunction(assertOverride));
 }
 
 function executeCode() {


### PR DESCRIPTION
- Add functionality to execute code on the client side (can be started and stopped by users)
- Add `alert()` function override inside the sandbox so that when `alert()` is called inside the sandbox, the output will be displayed on the page
- Add `assert()` function override for uses in test case. 
- Add syntax error and reference error detection in the sandbox. This prevents the interpreter from failing silently when encountering invalid JavaScript. Instead, an error will be displayed on the page.

Example of usage:
https://screenshot.googleplex.com/T3tyJ8uvg9C.png (`alert()` and `assert()`)
https://screenshot.googleplex.com/gW8PgwVuBmP.png (invalid JavaScript syntax)
https://screenshot.googleplex.com/e54enk8vpi4.png (invalid reference)