### PR TITLE
Finish simple backend interpreter module

### DIFF
--- a/modules/code_sandbox_manager.js
+++ b/modules/code_sandbox_manager.js
@@ -1,0 +1,72 @@
+/**
+ * Module that provides the ability to run JavaScript in a sandbox.
+ * This module creates a child process, captures its stdout and stderr,
+ * then returns an object containing both.
+ *
+ *
+ * Notes on capturing stdout / stderr design:
+ * This design is used due to the nature of the interpreter sandboxing.
+ * I originally intended to capture the stdout and stderr by passing an object
+ * from outside of the sandbox to inside.
+ * The sandboxed environment can then pass informations by modifying said object.
+ *
+ * However, the sandboxing library prevents this from happening.
+ * Any objects created and passed to the sandboxed environment will be deep-copied
+ * when we pass the object with seemingly no way to get it out except than to
+ * rewrite and overwrite functions declared in the library.
+ *
+ * Relaying information by printing to stdout and stderr directly, however,
+ * works completely fine. It seems like this is because the libary doesn't
+ * make a new stream for every file descriptor it receives, unlike objects.
+ *
+ *
+ * Notes on manager / worker design:
+ * The manager / worker design is chosen as it provides useful abstractions
+ * and advantages over a monolithic module that just runs the interpreter:
+ * - By spawning a child worker process, we can better manage each sandboxed
+ *   unit and enforce restrictions such as runtime limit. If we don't spawn
+ *   a child worker, we have to work around the nature of the sandbox such as
+ *   only being able to prevent infinite loop from hogging resources by
+ *   setting a timeout, which is considerably slow.
+ *
+ * - Should other languages be supported in the future, this design can adapt
+ *   to support them pretty well. For example, this module can be modified
+ *   such that it acts as a composer for docker container which could run
+ *   different languages.
+ *
+ * - This design is more adaptable should there be design changes in the future.
+ *   For example, should there be a need to do code queueing in the future,
+ *   we can modify this manager to act as a publisher and its worker to acts
+ *   as consumers.
+ *
+ **/
+const child         = require('child_process');
+const path          = require('path'); 
+
+const childScript   = path.join(__dirname, 'code_sandbox_worker.js');
+
+function run(code) {
+  // Passes in code through stdin of child process.
+  // Also prevents child process from printing to console.
+  let childCommand  = 'node ' + childScript;
+  let execOption    = {'input': code, 'stdio': 'pipe'};
+
+  let childStdout;
+  let childStderr;
+
+  // Captures the child process' stdout and stderr
+  // and returns it to the caller.
+  try {
+    childStdout = child.execSync(childCommand, execOption).toString();
+  } catch (error) {
+    childStdout = error.stdout.toString();
+    childStderr = error.stderr.toString();
+  }
+
+  return {
+    stdout: childStdout,
+    stderr: childStderr
+  };
+}
+
+module.exports.run = run;

--- a/modules/code_sandbox_worker.js
+++ b/modules/code_sandbox_worker.js
@@ -37,6 +37,6 @@ var overrideFunctions = function(interpreter, scope) {
 
 
 // Receives code from stdin, and execute it.
-let code = fs.readFileSync(0, 'utf-8');
+let code = fs.readFileSync(process.stdin.fd, 'utf-8');
 interpreter = new acornInterpreter.Interpreter(code, overrideFunctions);
 while(interpreter.step());

--- a/modules/code_sandbox_worker.js
+++ b/modules/code_sandbox_worker.js
@@ -1,0 +1,42 @@
+/**
+* Worker script that runs a JavaScript code inside a sandbox.
+*
+* This script doesn't attempt to capture any errors or
+* prevent mishaps such as infinite loop as they will be handled by the manager.
+*
+* Instead, the focus is to just run the sandboxed code as efficiently as possible. 
+**/
+global.acorn            = require('../lib/js_interpreter/acorn_interpreter.js');
+const acornInterpreter  = require('../lib/js_interpreter/acorn_interpreter.js');
+const fs                = require('fs');
+
+
+/**
+ * Function to override functions call inside the sandbox interpreter.
+ * This function serves as an interface between the server node runtime and the sandbox.
+ * 
+ * By overriding alert() in the sandbox for example, we can modify alert()
+ * so that its result can be redirected to console.log() in the server node runtime.
+ **/
+var overrideFunctions = function(interpreter, scope) {
+  let alertOverride = function(text) {
+    console.log(text);
+  };
+
+  let assertOverride = function(isTrue, message) {
+    if (!isTrue) {
+      throw (message || "Assertion failed");
+    }
+  }
+
+  interpreter.setProperty(scope, 'alert', 
+    interpreter.createNativeFunction(alertOverride));
+  interpreter.setProperty(scope, 'assert', 
+    interpreter.createNativeFunction(assertOverride));
+}
+
+
+// Receives code from stdin, and execute it.
+let code = fs.readFileSync(0, 'utf-8');
+interpreter = new acornInterpreter.Interpreter(code, overrideFunctions);
+while(interpreter.step());

--- a/test/code_sandbox.test.js
+++ b/test/code_sandbox.test.js
@@ -1,4 +1,4 @@
-const sandbox = require('../modules/code_sandbox.js');
+const sandbox = require('../modules/code_sandbox_manager.js');
 const assert = require('assert');
 
 describe('Code Sandbox', function () {

--- a/test/code_sandbox.test.js
+++ b/test/code_sandbox.test.js
@@ -1,0 +1,77 @@
+const sandbox = require('../modules/code_sandbox.js');
+const assert = require('assert');
+
+describe('Code Sandbox', function () {
+  describe('alert()', function () {
+    it(`should be connected to sandbox host's stdout`, function () {
+      const code      = `alert('Hello there!');`;
+      const result    = sandbox.run(code);
+
+      assert.equal(result.stdout, 'Hello there!\n');
+    });
+  });
+
+  describe('alert()', function () {
+    it(`should be connected to sandbox host's stderr`, function () {
+      const code      = `assert(false);`;
+      const result    = sandbox.run(code);
+
+      assert.ok(result.stderr.includes('Assertion failed\n'));
+    });
+
+    it(`should be able to display custom message`, function () {
+      const code      = `assert(false, 'Something went wrong');`;
+      const result    = sandbox.run(code);
+
+      assert.ok(result.stderr.includes('Something went wrong\n'));
+    });
+
+    it(`should stop program on first false assertion`, function () {
+      const code = `
+      alert(1);
+      assert(true);
+      alert(2);
+      assert(false);
+      alert(3);
+      `;
+
+      const result = sandbox.run(code);
+
+      assert.ok(result.stderr.includes('Assertion failed\n'));
+      assert.equal(result.stdout, '1\n2\n');
+    });
+  });
+
+
+  describe('interpreter', function () {
+    it(`should detect invalid JavaScript syntax`, function () {
+      const code = `
+      package main
+      import "fmt"
+
+      func main() {
+        fmt.Println("hello world")
+      }
+      `;
+
+      const result = sandbox.run(code);
+
+      assert.ok(result.stderr.includes('SyntaxError: Unexpected token (2:14)'));
+    });
+
+    it(`should detect undeclared function reference`, function () {
+      const code = `alert(go());`;
+      const result = sandbox.run(code);
+
+      assert.ok(result.stderr.includes('ReferenceError: go is not defined'));
+    });
+
+    it(`should detect undeclared variable reference`, function () {
+      const code = `alert(str);`;
+      const result = sandbox.run(code);
+
+      assert.ok(result.stderr.includes('ReferenceError: str is not defined'));
+    });
+  });
+});
+


### PR DESCRIPTION
- Add `/modules` directory to store server side Node files.
- Add test cases for basic usages of code sandbox module.
- Node server can now run codes by importing `modules/code_sandbox_manager.js`. Note that this only works with basic usages as of now (no infinite loop detection, etc.)
