### PR TITLE
Simplify routing configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,14 +6,19 @@ const path      = require('path');
 const express   = require('express');
 const app       = express();
 
-app.use('/html', express.static(path.join(__dirname, 'html')))
+/**
+* Responds to requests for routes by giving html files with the same name if possible.
+* Ex: Client will get /html/hello.html when sending a request to /hello
+**/
+app.use('/', express.static(path.join(__dirname, 'html'), {extensions:['html']}));
+
+/**
+* Binds the routes /scripts, /stylesheets, and /lib with their corresponding directory.
+* Ex: client will get /scripts/hello.js when sending request to /scripts/client.js
+**/
 app.use('/scripts', express.static(path.join(__dirname, 'scripts')))
 app.use('/stylesheets', express.static(path.join(__dirname, 'stylesheets')))
 app.use('/lib', express.static(path.join(__dirname, 'lib')))
-
-app.get('/solve', function(request, response){
-  response.sendFile('html/solve.html', { root: __dirname });
-});
 
 app.listen(PORT, () => console.log(`App listening on port ${PORT}`))
 module.exports = app;


### PR DESCRIPTION
Since we are starting to add more routes, I updated our routing configuration to make it easier when we add new routes or update existing ones.

The server will now respond to requests for routes by giving html files with the same name if possible.

Examples:
- To add `/hello` page, simply make `/html/hello.html`
- To edit `/old` route to `/new` route, change `/html/old.html` to `/html/new.html`