### PR TITLE
Add timeout feature for sandbox module

### DIFF
--- a/modules/code_sandbox_manager.js
+++ b/modules/code_sandbox_manager.js
@@ -43,29 +43,38 @@
 const child         = require('child_process');
 const path          = require('path'); 
 
-const childScript   = path.join(__dirname, 'code_sandbox_worker.js');
+const CHILD_SCRIPT      = path.join(__dirname, 'code_sandbox_worker.js');
+const DEFAULT_TIMEOUT   = 1500;
 
-function run(code) {
+function run(code, timeout) {
   // Passes in code through stdin of child process.
   // Also prevents child process from printing to console.
-  let childCommand  = 'node ' + childScript;
-  let execOption    = {'input': code, 'stdio': 'pipe'};
+  // Sets a timeout (in milliseconds) if given, uses DEFAULT_TIMEOUT otherwise
+  let childCommand  = 'node ' + CHILD_SCRIPT;
+  let execOption    = {
+    'input': code, 
+    'stdio': 'pipe', 
+    'timeout': timeout || DEFAULT_TIMEOUT
+  };
 
   let childStdout;
   let childStderr;
+  let childSignal;
 
-  // Captures the child process' stdout and stderr
+  // Captures the child process' stdout, stderr, and signal when terminated
   // and returns it to the caller.
   try {
     childStdout = child.execSync(childCommand, execOption).toString();
   } catch (error) {
     childStdout = error.stdout.toString();
     childStderr = error.stderr.toString();
+    childSignal = error.signal;
   }
 
   return {
     stdout: childStdout,
-    stderr: childStderr
+    stderr: childStderr,
+    signal: childSignal
   };
 }
 

--- a/test/code_sandbox.test.js
+++ b/test/code_sandbox.test.js
@@ -73,5 +73,21 @@ describe('Code Sandbox', function () {
       assert.ok(result.stderr.includes('ReferenceError: str is not defined'));
     });
   });
+
+  describe('timeout', function () {
+    it(`should prevent infinite loop given a timeout argument`, function () {
+      const code = `while(true);`;
+      const result = sandbox.run(code, 100);
+
+      assert.equal(result.signal, 'SIGTERM');
+    });
+
+    it(`should use default timeout when not given an explicit argument`, function () {
+      const code = `while(true);`;
+      const result = sandbox.run(code);
+
+      assert.equal(result.signal, 'SIGTERM');
+    });
+  });
 });
 


### PR DESCRIPTION
- Add test cases for sandbox module timeout
- Add feature so that timeout can now be explicitly set when running a sandboxed code in the server (if none is specified, default timeout specified in the module will be used)