### PR TITLE
Add routing configuration and example route

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,27 +5,48 @@ const PORT      = process.env.PORT || 8080;
 const path      = require('path'); 
 const express   = require('express');
 const exphbs    = require('express-handlebars');
+const fs        = require('fs');
 const app       = express();
 
 /**
-* Setup express handlebars as our templating engine.
-**/
+ * Recursively import all route handlers in /routes.
+ **/
+function importRoutes(dirName) {
+  fs.readdirSync(dirName).forEach(function(fileName) {
+
+    let fullName    = path.join(dirName, fileName);
+    let stat        = fs.lstatSync(fullName);
+
+    if (stat.isDirectory()) {
+      importRoutes(fullName);
+    } 
+
+    if (path.extname(fullName) === '.js') {
+      require(fullName)(app);
+    }
+  });
+}
+importRoutes(path.join(__dirname, 'routes'));
+
+/**
+ * Setup express handlebars as our templating engine.
+ **/
 app.engine('hbs', exphbs({defaultLayout: 'main', extname: 'hbs'}));
 app.set('views', path.join(__dirname, 'html'));
 app.set('view engine', 'hbs');
 
 /**
-* Binds the routes /scripts, /stylesheets, and /lib with their corresponding directory.
-* Ex: client will get /scripts/hello.js when sending request to /scripts/client.js
-**/
+ * Binds the routes /scripts, /stylesheets, and /lib with their corresponding directory.
+ * Ex: client will get /scripts/hello.js when sending request to /scripts/client.js
+ **/
 app.use('/scripts', express.static(path.join(__dirname, 'scripts')));
 app.use('/stylesheets', express.static(path.join(__dirname, 'stylesheets')));
 app.use('/lib', express.static(path.join(__dirname, 'lib')));
 
 /**
-* Responds to requests for routes by giving html files with the same name if possible.
-* Ex: When the route /hello is requested, the server will render the file hello.hbs
-**/
+ * Responds to requests for routes by giving html files with the same name if possible.
+ * Ex: When the route /hello is requested, the server will render the file hello.hbs
+ **/
 app.use('/', function(request, response, next) {
   response.render(request.originalUrl.slice(1));
 });

--- a/html/layouts/main.hbs
+++ b/html/layouts/main.hbs
@@ -11,10 +11,10 @@
     <script src="/scripts/auth.js"></script>
 
     <!-- CodeMirror, Interpreter, and JSHint JavaScript imports -->
-    <script src="lib/codemirror/lib/codemirror.js"></script>
-    <script src="lib/codemirror/mode/javascript/javascript.js"></script>
-    <script src="lib/js_interpreter/acorn_interpreter.js"></script>
-    <script src="lib/jshint-2.11.1/jshint.js"></script>
+    <script src="/lib/codemirror/lib/codemirror.js"></script>
+    <script src="/lib/codemirror/mode/javascript/javascript.js"></script>
+    <script src="/lib/js_interpreter/acorn_interpreter.js"></script>
+    <script src="/lib/jshint-2.11.1/jshint.js"></script>
     <script src="/scripts/solve.js"></script> 
     
     <!-- BootStrap JavaScript imports -->
@@ -24,7 +24,7 @@
     
     <!-- BootStrap CSS imports -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-    <link rel="stylesheet" href="lib/codemirror/lib/codemirror.css">
+    <link rel="stylesheet" href="/lib/codemirror/lib/codemirror.css">
     
     <!--Our personal stylings-->
     <link rel="stylesheet" href="/stylesheets/style.css">

--- a/html/solve.hbs
+++ b/html/solve.hbs
@@ -3,10 +3,10 @@
   <div class="col-3">
     <div class="card fill">
       <div class="card-header">
-        <h5 class="card-title" id="question-title"></h5>
+        <h5 class="card-title" id="question-title">{{ question-title }}</h5>
       </div>
       <div class="card-body">
-        <p class="card-text" id="question-text"></p>
+        <p class="card-text" id="question-text">{{ question-text }}</p>
       </div>
     </div>
   </div>

--- a/html/solve.hbs
+++ b/html/solve.hbs
@@ -12,6 +12,7 @@
   </div>
 
   <div class="col-6" id="code-area"></div>
+  <input type="hidden" id="initial-code" value="{{ initial-code }}">
 
   <div class="col-3">
     <div class="card fill">

--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -1,5 +1,10 @@
 module.exports = function(app) {
-  app.get('/problems/:id', function (req, res) {
-    res.send(req.params.id);
+  app.get('/problems/:id', function (request, response) {
+    let dynamicContent = {
+      'question-title': 'Placeholder title for /problems/' + request.params.id,
+      'question-text' : 'Placeholder text for /problems/' + request.params.id
+    }
+
+    response.render('solve', dynamicContent);
   });
 }

--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -1,8 +1,9 @@
 module.exports = function(app) {
   app.get('/problems/:id', function (request, response) {
     let dynamicContent = {
-      'question-title': 'Placeholder title for /problems/' + request.params.id,
-      'question-text' : 'Placeholder text for /problems/' + request.params.id
+      'question-title'  : 'Placeholder title for /problems/' + request.params.id,
+      'question-text'   : 'Placeholder text for /problems/' + request.params.id,
+      'initial-code'    : `alert('Placeholder initial code for /problems/` + request.params.id + `')`
     }
 
     response.render('solve', dynamicContent);

--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -1,0 +1,5 @@
+module.exports = function(app) {
+  app.get('/problems/:id', function (req, res) {
+    res.send(req.params.id);
+  });
+}

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -1,4 +1,4 @@
-const SAMPLE_CODE       = 'function myScript(){return 100;}\n';
+const INITIAL_CODE_ID   = 'initial-code';
 const CODE_AREA_ID      = 'code-area';
 const CODE_OUTPUT_ID    = 'code-output';
 const RUN_BUTTON_ID     = 'run-button';
@@ -24,7 +24,7 @@ window.addEventListener('load', function() {
  **/
 function setupCodeMirror() {
   codeMirror = CodeMirror(document.getElementById(CODE_AREA_ID), {
-    value: SAMPLE_CODE,
+    value: document.getElementById(INITIAL_CODE_ID).value,
     mode:  'javascript',
     lineNumbers: true,
   });


### PR DESCRIPTION
- Add `routes` directory to store any route handlers. All `.js` files in the directory will be recursively imported by `app.js`, allowing easier decomposition and structuring of route handlers.
- Add route handler for `/problems/:id` that can dynamically generate pages according to `:id`.
- Fix import paths in `/html/layouts/main.hbs` being relative instead of absolute, causing import errors.

Example:
[/problems/1](https://screenshot.googleplex.com/VpZthqga7X7.png)
[/problems/200](https://screenshot.googleplex.com/uBfZG9Q36kz.png)