### PR TITLE
Validate username by matching against a regex

### DIFF
--- a/html/partials/register.hbs
+++ b/html/partials/register.hbs
@@ -20,9 +20,9 @@
 
           <div class="form-group">
             <label for="username">Username</label>
-            <input type="text" class="form-control" id="username" name="username" required>
+            <input type="text" class="form-control" id="username" name="username" pattern="[a-zA-Z0-9_]+" required>
             <div class="invalid-feedback" id="invalid-feedback">
-              Please provide your username.
+              Please provide your username. Usernames should only contain alphanumeric characters and underscores.
             </div>
           </div>
         </div>

--- a/routes/register.js
+++ b/routes/register.js
@@ -4,8 +4,21 @@ const multer  = require('multer');
 
 const USER_KIND = "User";
 
-// TODO (b/161373767) Add further validation.
+/**
+ * Checks if a username is valid by testing against a regular
+ * expression and querying the database.
+ * @param {string} username 
+ * @returns {boolean}
+ */
 async function isValid(username) {
+  // Check that username contains only letters, digits, or
+  // underscores and is at least one character.
+  const regex = /\W/;
+  if (regex.test(username) || username.length === 0) {
+    return false;
+  }
+
+  // Query database to see if the username is taken
   const usernameQuery = datastore
       .createQuery(USER_KIND)
       .filter('username', '=', username)
@@ -16,12 +29,13 @@ async function isValid(username) {
 
 module.exports = function(app) {
   app.post('/register', multer().none(), async function(request, response) {
-    let validUsername
+    let validUsername;
     try {
       validUsername = await isValid(request.body.username);
     } catch(error) {
       response.sendStatus(500);
     }
+    
     if (validUsername) {
       try {
         await datastore.store(USER_KIND, request.body);


### PR DESCRIPTION
The valid characters are alphanumeric and/or underscores. Limiting usernames to these characters also allows us to avoid sanitizing them.