### PR TITLE
Add additional static analysis metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const exphbs    = require('express-handlebars');
 const fs        = require('fs');
 const app       = express();
 
+app.use(express.text());
 app.use(express.json());
 
 /**

--- a/html/solve.hbs
+++ b/html/solve.hbs
@@ -92,7 +92,8 @@
             <pre id="code-output"></pre>
           </div>
           <div class="tab-pane fade" id="analysis" role="tabpanel" aria-labelledby="analysis-tab">
-            <p id="analysis-output"></p>
+            <ul class="list-group list-group-flush" id="analysis-output">
+            </ul>
           </div>
         </div>
       </div>

--- a/modules/code_metrics.js
+++ b/modules/code_metrics.js
@@ -1,4 +1,4 @@
-const jshint = require('../lib/jshint-2.11.1/jshint.js')
+const escomplex = require('escomplex');
 
 /**
  * Performs static analysis on code 
@@ -7,14 +7,15 @@ const jshint = require('../lib/jshint-2.11.1/jshint.js')
  */
 
 function analyze(code) {
-  jshint.JSHINT(code);
-  result = jshint.JSHINT.data();
-  
-  // Get total complexity from result object
-  complexity = result.functions
-    .map(item => item.metrics.complexity)
-    .reduce((acc, curr) => acc + curr, 0);
-  return {'complexity': complexity};
+  const result = escomplex.analyse(code);
+
+  // Round to 3 decimal places if needed
+  roundedDifficulty = +(result.aggregate.halstead.difficulty.toFixed(3));
+  return {
+    cyclomatic: result.aggregate.cyclomatic,
+    lloc: result.aggregate.sloc.logical,
+    difficulty: roundedDifficulty
+  };
 }
 
 module.exports = analyze;

--- a/package-lock.json
+++ b/package-lock.json
@@ -359,6 +359,11 @@
         }
       }
     },
+    "check-types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-5.1.0.tgz",
+      "integrity": "sha1-NzlN07YEKlEVXpJsOpF1PUmeXcg="
+    },
     "chokidar": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
@@ -691,6 +696,14 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escomplex": {
+      "version": "2.0.0-alpha",
+      "resolved": "https://registry.npmjs.org/escomplex/-/escomplex-2.0.0-alpha.tgz",
+      "integrity": "sha1-/Wp5hl2br1fEw+0bL+Z3cU5ElgY=",
+      "requires": {
+        "check-types": "^5.1.0"
+      }
     },
     "esprima": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@google-cloud/datastore": "^6.1.0",
     "darkmode-js": "^1.5.6",
+    "escomplex": "^2.0.0-alpha",
     "express": "^4.16.3",
     "express-handlebars": "^4.0.4",
     "google-auth-library": "^6.0.3",

--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -94,4 +94,14 @@ module.exports = function(app) {
       'Click OK to compare it to other solutions!'
     );
   });
+
+  app.post('/analysis', function(request, response) {
+    try {
+      const results = analyze(request.body);
+      response.send(results);
+    } catch (error) {
+      // Library throws error if it can't parse the source code.
+      response.sendStatus(400);
+    }
+  });
 }

--- a/scripts/solve.js
+++ b/scripts/solve.js
@@ -1,21 +1,23 @@
 import { idToken } from './auth.js';
 
-const INITIAL_CODE_ID   = 'initial-code';
-const CODE_AREA_ID      = 'code-area';
-const CODE_OUTPUT_ID    = 'code-output';
-const ANALYSIS_OUTPUT_ID = 'analysis-output'
-const RUN_BUTTON_ID     = 'run-button';
-const STOP_BUTTON_ID    = 'stop-button';
-const SUBMIT_BUTTON_ID  = 'submit-button';
-const RESET_BUTTON_ID   = 'reset-button';
-const KEYBIND_CLASS     = 'keybind';
-const OUTPUT_TAB_ID     = 'output-tab';
-const ANALYSIS_TAB_ID   = 'analysis-tab';
-const HIDDEN_ATTRIBUTE  = 'hidden';
-const NEWLINE           = '\n';
-const SOLUTION_FUNCTION = 'solution';
-const KEYBIND_KEY       = 'keybind';
-const LOADING_BUTTON    = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>Loading...';
+const INITIAL_CODE_ID    = 'initial-code';
+const CODE_AREA_ID       = 'code-area';
+const CODE_OUTPUT_ID     = 'code-output';
+const ANALYSIS_OUTPUT_ID = 'analysis-output';
+const RUN_BUTTON_ID      = 'run-button';
+const STOP_BUTTON_ID     = 'stop-button';
+const SUBMIT_BUTTON_ID   = 'submit-button';
+const RESET_BUTTON_ID    = 'reset-button';
+const KEYBIND_CLASS      = 'keybind';
+const OUTPUT_TAB_ID      = 'output-tab';
+const ANALYSIS_TAB_ID    = 'analysis-tab';
+const HIDDEN_ATTRIBUTE   = 'hidden';
+const NEWLINE            = '\n';
+const KEYBIND_KEY        = 'keybind';
+const LOADING_BUTTON     = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>Loading...';
+const DIFFICULTY_DESC    = 'Halstead difficulty is a metric calculated based on the number of operands and operators in the function. The higher the number, the more difficult a program is to understand (e.g. in a code review).';
+const LLOC_DESC          = 'Logical lines of code is a measure of the number of imperative statements in the program.';
+const CYCLOMATIC_DESC    = 'Cyclomatic complexity is a measure of the number linearly independent paths through a program.';
 
 let codeMirror;
 let outputArea;
@@ -186,6 +188,14 @@ function stopRunningCode() {
   updateInterface();
 }
 
+function generateTooltipHTMLString(title, alignment) {
+  let HTMLString = `<button type="button" class="close text-${alignment}" aria-label="Help"
+                    data-toggle="tooltip" title="${title}">
+                      <span aria-hidden="true">?</span>
+                    </button>`
+  return HTMLString;
+}
+
 async function runStaticAnalysis(code) {
   const response = await fetch('/analysis', {method: 'POST', body: code});
   if (!response.ok) {
@@ -202,9 +212,12 @@ async function runStaticAnalysis(code) {
   const metrics = {
     numFunctions: `Number of functions: ${results.functions.length}`,
     unused: `Unused functions and variables: ${unused.length > 0 ? unused.join(', ') : 'none'}.`,
-    cyclomatic: `The total cyclomatic complexity is ${analysis.cyclomatic}.`,
-    difficulty: `The Halstead difficulty is ${analysis.difficulty}.`,
-    lloc: `${analysis.lloc} logical lines of code.`
+    cyclomatic: `The total cyclomatic complexity is ${analysis.cyclomatic}.
+      ${generateTooltipHTMLString(CYCLOMATIC_DESC, 'right')}`,
+    difficulty: `The Halstead difficulty is ${analysis.difficulty}.
+      ${generateTooltipHTMLString(DIFFICULTY_DESC, 'right')}`,
+    lloc: `${analysis.lloc} logical lines of code.
+      ${generateTooltipHTMLString(LLOC_DESC, 'right')}`
   }
 
   document.getElementById(ANALYSIS_OUTPUT_ID).innerHTML = '';
@@ -214,6 +227,7 @@ async function runStaticAnalysis(code) {
     metricListItem.className = 'list-group-item';
     document.getElementById(ANALYSIS_OUTPUT_ID).appendChild(metricListItem);
   }
+  $('[data-toggle="tooltip"]').tooltip('enable');
 }
 
 async function submitSolution() {

--- a/test/code_metrics.test.js
+++ b/test/code_metrics.test.js
@@ -14,7 +14,7 @@ describe('Code Metrics Analyzer', function() {
                           }`
       const result = analyze(sourceCode);
       const expected = 2;
-      assert.strictEqual(result.complexity, expected);
+      assert.strictEqual(result.cyclomatic, expected);
     });
   });
 });


### PR DESCRIPTION
- This PR adds Halstead difficulty and logical lines of code to the metrics reported on the front end
- Also added a tooltip on hover to provide information about the various metrics
- Refactor analysis module to use ESComplex rather than JSHint

Screenshots
[UI for metrics](https://screenshot.googleplex.com/dzv9rXyU13C)
[Help text tooltip](https://screenshot.googleplex.com/n0iNCGE9fPA)