### PR TITLE
Fix issue where signout link wasn't in the collapse drawer

### DIFF
--- a/html/partials/nav.hbs
+++ b/html/partials/nav.hbs
@@ -13,10 +13,17 @@
           <a class="nav-link" href="/problems">Problems</a>
       </li>
     </ul>
-    <form class="form-inline my-2 my-lg-0">
-      <div class="g-signin2" id="signin-link" data-onsuccess="onSignIn"></div>
-      <a class="nav-link" href="#" id="profile-link" hidden>Profile</div>
-      <a class="nav-link" href="#" onclick="signOut();" id="signout-link" hidden>Sign out</a>
-    </form>
+
+    <ul class="navbar-nav">
+      <li class="nav-item">
+        <div class="g-signin2" id="signin-link" data-onsuccess="onSignIn"></div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#" id="profile-link" hidden>Profile</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#" onclick="signOut();" id="signout-link" hidden>Sign out</a>
+      </li>
+    </ul>
   </div>
 </nav>


### PR DESCRIPTION
- Before
![image](https://user-images.githubusercontent.com/43190126/88115211-46f37e00-cb7b-11ea-966b-559c5d8d9f21.png)

- After
![image](https://user-images.githubusercontent.com/43190126/88115244-5377d680-cb7b-11ea-9f18-a098db5d2172.png)

 
- Also made signout links `nav-item`s and removed the unnecessary form tag