### PR TITLE
Fix issues discovered post-integration of new static analysis metrics

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -10,7 +10,6 @@
 # If you would like to upload your .git directory, .gitignore file or files
 # from your .gitignore file, remove the corresponding line
 # below:
-.git
 .gitignore
 
 # Node.js dependencies:

--- a/html/layouts/main.hbs
+++ b/html/layouts/main.hbs
@@ -27,7 +27,6 @@
     <script src="/lib/codemirror/addon/hint/javascript-hint.js"></script>
     <script src="/lib/js_interpreter/acorn_interpreter.js"></script>
     <script src="/lib/jshint-2.11.1/jshint.js"></script>
-    <script src="/scripts/solve.js" type="module"></script> 
 
     {{!-- <!-- Darkmode JavaScript imports -->
     <script src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.6/lib/darkmode-js.min.js"></script>

--- a/html/solve.hbs
+++ b/html/solve.hbs
@@ -1,3 +1,5 @@
+<script src="/scripts/solve.js" type="module"></script> 
+
 <div class="row fill no-gutters">
 
   <div class="col-3">

--- a/problems/fibonacci.yaml
+++ b/problems/fibonacci.yaml
@@ -34,4 +34,4 @@ solution: |
     
     return fibonacci(num - 1) + fibonacci(num - 2);
   };
-timeout: 1000
+timeout: 3000

--- a/problems/fizzbuzz.yaml
+++ b/problems/fizzbuzz.yaml
@@ -41,4 +41,4 @@ solution: |
 
     return str;
   }
-timeout: 500
+timeout: 2000

--- a/problems/generateRepeated.yaml
+++ b/problems/generateRepeated.yaml
@@ -38,3 +38,4 @@ solution:
     var firstRepeat = repeatString(str, a);
     return repeatString(firstRepeat + '\n', b).trim();
   }
+timeout: 2500

--- a/problems/reverseString.yaml
+++ b/problems/reverseString.yaml
@@ -25,3 +25,4 @@ solution: |
   function reverseString(str) {
     return str.split('').reverse().join('');
   }
+timeout: 2500

--- a/problems/sumDigits.yaml
+++ b/problems/sumDigits.yaml
@@ -44,3 +44,4 @@ solution: |
     }
     return total;
   }
+timeout: 2500

--- a/routes/version.js
+++ b/routes/version.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * Sends the hash of the latest git commit.
+ * Used for debugging purpose.
+ **/
+module.exports = function(app) {
+  app.get('/version', async function(request, response) {
+    const LATEST_HASH = require('child_process')
+      .execSync('git rev-parse HEAD')
+      .toString()
+      .trim();
+
+    response.send(LATEST_HASH);
+  })
+}
+


### PR DESCRIPTION
- Fix [uncaught type error on the client](https://buganizer.corp.google.com/issues/161988144) due to importing `solve.js` on unrelated pages.
- Fix [code timing out on deployment](https://buganizer.corp.google.com/issues/161988136) due to differences in environment.
- Add `/version` route that will return the latest git commit hash on GET request to help debug future issues (`.git` has been removed from `.gcloudignore` so that it will also be copied during deployment build).