### PR TITLE
Convert analysis result values to datastore double

### DIFF
--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -31,6 +31,14 @@ async function getProblem(id) {
  * Fields in data are not nested to allow easier filtering.
  **/
 async function saveSubmission(user, code, analysisResult, problemId) {
+  // For numeric analysis results, store the property as a double
+  for (const key of Object.keys(analysisResult)) {
+    value = analysisResult[key]
+    if (!isNaN(value)) {
+      analysisResult[key] = datastore.double(value);
+    }
+  }
+
   const data        = analysisResult;
   data.username     = user.username;
   data.code         = code;

--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -31,12 +31,9 @@ async function getProblem(id) {
  * Fields in data are not nested to allow easier filtering.
  **/
 async function saveSubmission(user, code, analysisResult, problemId) {
-  // For numeric analysis results, store the property as a double
-  for (const key of Object.keys(analysisResult)) {
-    value = analysisResult[key]
-    if (!isNaN(value)) {
-      analysisResult[key] = datastore.double(value);
-    }
+  // Store Halstead difficulty as a double since it can be a float
+  if (analysisResult.difficulty) {
+    analysisResult.difficulty = datastore.double(analysisResult.difficulty);
   }
 
   const data        = analysisResult;


### PR DESCRIPTION
This fixes an issue where whole number values are ranked above floats.

Example:
[screenshot](https://screenshot.googleplex.com/ifwRRaMOQsC)