### PR TITLE
Add groundwork for code instrumentation module

### DIFF
--- a/modules/instrument_code.js
+++ b/modules/instrument_code.js
@@ -11,35 +11,35 @@ const escodegen = require('escodegen');
 const BLOCK_STATEMENT = 'BlockStatement';
 
 /**
-* Function that wraps optional single-liner in BlockStatement Node.
-* Takes in an Abstract Syntax Tree node and its parent,
-* and returns the appropriate replacement of the node.
-*
-* For example, given an AST node that represents doTask() in:
-* if (x == y)
-*   doTask();
-*
-* This code will return an AST node representing:
-* {
-*   doTask();
-* }
-*
-* Such that its caller can replace the AST node and generate:
-* if (x == y) {
-*   doTask();
-* }
-*
-* This function is needed so that further code instrumentation
-* will not accidentally change the behaviour of the original code
-* due to accidents such as:
-* if (x == y)
-*   doTask();
-*
-* turning into:
-* if (x == y)
-*   detectBranchCoverage();
-* doTask();
-**/
+ * Function that wraps optional single-liner in BlockStatement Node.
+ * Takes in an Abstract Syntax Tree node and its parent,
+ * and returns the appropriate replacement of the node.
+ *
+ * For example, given an AST node that represents doTask() in:
+ * if (x == y)
+ *   doTask();
+ *
+ * This code will return an AST node representing:
+ * {
+ *   doTask();
+ * }
+ *
+ * Such that its caller can replace the AST node and generate:
+ * if (x == y) {
+ *   doTask();
+ * }
+ *
+ * This function is needed so that further code instrumentation
+ * will not accidentally change the behaviour of the original code
+ * due to accidents such as:
+ * if (x == y)
+ *   doTask();
+ *
+ * turning into:
+ * if (x == y)
+ *   detectBranchCoverage();
+ * doTask();
+ **/
 function wrapInBlockStatement(node, parent) {
   const wrappedNode = acorn.parse('{' + escodegen.generate(node) + '}');
 

--- a/modules/instrument_code.js
+++ b/modules/instrument_code.js
@@ -1,0 +1,68 @@
+/**
+ * Module that implements source code instrumentation.
+ **/
+
+'use strict';
+
+const acorn = require('acorn');
+const estraverse = require('estraverse');
+const escodegen = require('escodegen');
+
+const BLOCK_STATEMENT = 'BlockStatement';
+
+/**
+* Function that wraps optional single-liner in BlockStatement Node.
+* Takes in an Abstract Syntax Tree node and its parent,
+* and returns the appropriate replacement of the node.
+*
+* For example, given an AST node that represents doTask() in:
+* if (x == y)
+*   doTask();
+*
+* This code will return an AST node representing:
+* {
+*   doTask();
+* }
+*
+* Such that its caller can replace the AST node and generate:
+* if (x == y) {
+*   doTask();
+* }
+*
+* This function is needed so that further code instrumentation
+* will not accidentally change the behaviour of the original code
+* due to accidents such as:
+* if (x == y)
+*   doTask();
+*
+* turning into:
+* if (x == y)
+*   detectBranchCoverage();
+* doTask();
+**/
+function wrapInBlockStatement(node, parent) {
+  const wrappedNode = acorn.parse('{' + escodegen.generate(node) + '}');
+
+  // Prevents nested BlockStatement wrapping
+  if (node.type == BLOCK_STATEMENT) {
+    return node;
+  }
+
+  // Handles wrapping for conditionals such as if and else statement
+  if (parent.consequent == node || parent.alternate == node) {
+    return wrappedNode;
+  }
+
+  // Handles wrapping for loops such as for and while statement
+  if (parent.body == node) {
+    return wrappedNode;
+  }
+
+  return node;
+}
+
+
+module.exports = {
+  wrapInBlockStatement: wrapInBlockStatement,
+};
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -544,6 +544,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -711,6 +716,25 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        }
+      }
+    },
     "escomplex": {
       "version": "2.0.0-alpha",
       "resolved": "https://registry.npmjs.org/escomplex/-/escomplex-2.0.0-alpha.tgz",
@@ -728,6 +752,11 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
       "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -792,6 +821,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-text-encoding": {
       "version": "1.0.3",
@@ -1291,6 +1325,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -1559,6 +1602,19 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -1609,6 +1665,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -2018,6 +2079,14 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -2086,6 +2155,11 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,11 @@
         "negotiator": "0.6.2"
       }
     },
+    "acorn": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+    },
     "agent-base": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
@@ -718,6 +723,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+      "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw=="
     },
     "etag": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "dependencies": {
     "@google-cloud/datastore": "^6.1.0",
     "cookie-parser": "^1.4.5",
+    "acorn": "^7.3.1",
     "darkmode-js": "^1.5.6",
     "escomplex": "^2.0.0-alpha",
+    "estraverse": "^5.1.0",
     "express": "^4.16.3",
     "express-handlebars": "^4.0.4",
     "google-auth-library": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cookie-parser": "^1.4.5",
     "acorn": "^7.3.1",
     "darkmode-js": "^1.5.6",
+    "escodegen": "^1.14.3",
     "escomplex": "^2.0.0-alpha",
     "estraverse": "^5.1.0",
     "express": "^4.16.3",

--- a/test/instrument_code.test.js
+++ b/test/instrument_code.test.js
@@ -1,0 +1,122 @@
+const codeInstrumenter = require('../modules/instrument_code.js');
+const acorn = require('acorn');
+const estraverse = require('estraverse');
+const escodegen = require('escodegen');
+const assert = require('assert');
+
+/**
+* Helper function to delete all whitespaces in code
+* including space characters, tab spaces, and newlines.
+*
+* Used in testing as we don't expect the instrumented code
+* to properly follow all indentation rules.
+**/
+function stripSpace(code) {
+  return code.replace(/\s/g,'');
+}
+
+/**
+* Helper function to generate instrumented code.
+* Takes in a code and an instrumentFunction.
+*
+* An abstract syntax tree representing the code will be generated.
+* The syntax tree will then be traveled node by node, where
+* each node will be replaced with the node returned by the instrumentFunction.
+* After the traversal ends, a generated code is returned.
+**/
+function instrumentCode(originalCode, instrumentFunction) {
+  let codeAst = acorn.parse(originalCode);
+
+  estraverse.replace(codeAst, {
+    leave: function (node, parent) {
+      return instrumentFunction(node, parent);
+    }
+  });
+
+  return escodegen.generate(codeAst);
+}
+
+describe('Code Instrumentation module', () => {
+  describe('wrapInBlockStatement()', () => {
+    it('should handle simple single-liners properly', () => {
+      const originalCode = `
+      if (1 == 1)
+        var x = 2;
+      else
+        var y = 1;
+
+      for (var i = 0; i < 12; i++)
+        doTask();
+
+      while (true)
+        var z = 3;
+      `;
+
+      const expectedCode = `
+      if (1 == 1) {
+        var x = 2;
+      } else {
+        var y = 1;
+      }
+
+      for (var i = 0; i < 12; i++) {
+        doTask();
+      }
+
+      while (true) {
+        var z = 3;
+      }
+      `;
+
+      const generatedCode = 
+        instrumentCode(originalCode, codeInstrumenter.wrapInBlockStatement);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
+    });
+
+
+    it('should only wrap the first statement in a single-liner', () => {
+      const originalCode = `
+      if (1 == 1) var x = 2; var z = 3;
+      `;
+
+      const expectedCode = `
+      if (1 == 1) {
+        var x = 2;
+      } 
+      var z = 3;
+      `;
+
+      const generatedCode = 
+        instrumentCode(originalCode, codeInstrumenter.wrapInBlockStatement);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
+    });
+
+    it('should only wrap statements when needed', () => {
+      const originalCode = `
+      if (1 == 1) {
+        var x = 2;
+      } 
+
+      if (1 == 2)
+        var z = 3;
+      `;
+
+      const expectedCode = `
+      if (1 == 1) {
+        var x = 2;
+      } 
+
+      if (1 == 2) {
+        var z = 3;
+      }
+      `;
+
+      const generatedCode = 
+        instrumentCode(originalCode, codeInstrumenter.wrapInBlockStatement);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
+    });
+  });
+});


### PR DESCRIPTION
This PR adds `instrument_code.js` (will be used to do code instrumentation such as detecting user's test coverage) and its tests.

The module currently contains function to wrap statements in BlockWrapping when needed.
For example:
```
if (true)
  doTask();
```
will become:
```
if (true) {
  doTask();
}
```
This functionality will be used to prepare user code before further instrumentation which might change code behavior should BlockStatement wrapping be absent.

For example, the previous example might turn into:
```
if (true)
  detectBranchCoverage();
doTask();
```
without BlockStatement wrapping in place.