### PR TITLE
Order a user's solved problems by timestamp

### DIFF
--- a/routes/users_id.js
+++ b/routes/users_id.js
@@ -22,7 +22,8 @@ module.exports = function(app) {
   async function listSolutionsByUser(user) {
     const query = datastore
         .createQuery(SOLUTION_KIND)
-        .filter('username', '=', user.username);
+        .filter('username', '=', user.username)
+        .order('timestamp', {descending: true});
     const [userSolutions] = await datastore.runQuery(query);
     return userSolutions;
   }


### PR DESCRIPTION
Add order by timestamp to solutions query since datastore doesn't give query results in a consistent order 

[Before](https://screenshot.googleplex.com/fFQvSKXEVrm.png)
[After](https://screenshot.googleplex.com/qDnXUCL0d00.png)