### PR TITLE
Add functionality to generate code with statement coverage instrumentation

### DIFF
--- a/modules/instrument_code.js
+++ b/modules/instrument_code.js
@@ -8,10 +8,7 @@ const acorn = require('acorn');
 const estraverse = require('estraverse');
 const escodegen = require('escodegen');
 
-const sandbox = require('./code_sandbox_manager');
-
 const BLOCK_STATEMENT = 'BlockStatement';
-const RETURN_STATEMENT = 'ReturnStatement';
 const IF_STATEMENT = 'IfStatement';
 
 const INSTRUMENTATION_HEADER = `

--- a/test/instrument_code.test.js
+++ b/test/instrument_code.test.js
@@ -119,4 +119,80 @@ describe('Code Instrumentation module', () => {
       assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
     });
   });
+
+  describe('addStatementCoverageDetection()', () => {
+    it('add instrumentation functions before a statement rather than after', () => {
+      const originalCode = `
+      function solution() {
+        return 1;
+      }
+      `;
+
+      const expectedCode = `
+      function solution() {
+        coverageReport.recordExecutedStatement(37);
+        return 1;
+      }
+      `;
+
+      const generatedCode = 
+        instrumentCode(originalCode, codeInstrumenter.addStatementCoverageDetection);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
+    });
+
+    it('should not be affected by multiple statements in one line', () => {
+      const originalCode = `
+      function solution() {
+        var x = 1; return x;
+      }
+      `;
+
+      const expectedCode = `
+      function solution() {
+        coverageReport.recordExecutedStatement(37);
+        var x = 1;
+
+        coverageReport.recordExecutedStatement(48);
+        return x;
+      }
+      `;
+
+      const generatedCode = 
+        instrumentCode(originalCode, codeInstrumenter.addStatementCoverageDetection);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
+    });
+
+    it('should generate instrumented functions with unique arguments', () => {
+      const originalCode = `
+      function solution() {
+        var x = 1;
+        x = 2;
+        x = 3;
+        
+        return x;
+      }
+      `;
+
+      const expectedCode = `
+      function solution() {
+        coverageReport.recordExecutedStatement(37);
+        var x = 1;
+        coverageReport.recordExecutedStatement(56);
+        x = 2;
+        coverageReport.recordExecutedStatement(71);
+        x = 3;
+
+        coverageReport.recordExecutedStatement(95);
+        return x;
+      }
+      `;
+
+      const generatedCode = 
+        instrumentCode(originalCode, codeInstrumenter.addStatementCoverageDetection);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
+    });
+  });
 });

--- a/test/instrument_code.test.js
+++ b/test/instrument_code.test.js
@@ -195,4 +195,66 @@ describe('Code Instrumentation module', () => {
       assert.equal(stripSpace(expectedCode), stripSpace(generatedCode));
     });
   });
+
+  describe('generateInstrumentedCode()', () => {
+    it('should generate code that includes the instrumentation header', () => {
+      const code = `
+      function solve() {
+        return 1;
+      }
+      `;
+
+      const instrumentationResult = codeInstrumenter.generateInstrumentedCode(code);
+      const instrumentedCode = instrumentationResult.code;
+
+      assert.ok(instrumentedCode.includes(codeInstrumenter.INSTRUMENTATION_HEADER));
+    });
+
+    it('should generate code that includes the instrumentation footer', () => {
+      const code = `
+      function solve() {
+        return 1;
+      }
+      `;
+
+      const instrumentationResult = codeInstrumenter.generateInstrumentedCode(code);
+      const instrumentedCode = instrumentationResult.code;
+
+      assert.ok(instrumentedCode.includes(codeInstrumenter.INSTRUMENTATION_FOOTER));
+    });
+
+    it('should handle one-liner statements properly', () => {
+      const code = `
+      function solve() {
+        if (true)
+          doThis(); doThat();
+
+        return 1;
+      }
+      `;
+
+      const expectedCode = `
+      ${codeInstrumenter.INSTRUMENTATION_HEADER}
+      function solve() {
+        coverageReport.recordExecutedStatement(34);
+        if (true) {
+          coverageReport.recordExecutedStatement(54);
+          doThis();
+        }
+
+        coverageReport.recordExecutedStatement(64);
+        doThat();
+
+        coverageReport.recordExecutedStatement(83);
+        return 1;
+      }
+      ${codeInstrumenter.INSTRUMENTATION_FOOTER}
+      `;
+
+      const instrumentationResult = codeInstrumenter.generateInstrumentedCode(code);
+      const instrumentedCode = instrumentationResult.code;
+
+      assert.equal(stripSpace(expectedCode), stripSpace(instrumentedCode));
+    });
+  });
 });

--- a/test/instrument_code.test.js
+++ b/test/instrument_code.test.js
@@ -251,10 +251,14 @@ describe('Code Instrumentation module', () => {
       ${codeInstrumenter.INSTRUMENTATION_FOOTER}
       `;
 
+      const expectedStatementCount = 4;
+
       const instrumentationResult = codeInstrumenter.generateInstrumentedCode(code);
       const instrumentedCode = instrumentationResult.code;
+      const totalStatementCount = instrumentationResult.totalStatementCount;
 
       assert.equal(stripSpace(expectedCode), stripSpace(instrumentedCode));
+      assert.equal(expectedStatementCount, totalStatementCount);
     });
   });
 });


### PR DESCRIPTION
`instrument_code.js` can now generate instrumented code that tells us how many of its statements were executed.

For example:
```
function solve() {
  if (true)
    doThis(); doThat();
  
  return 1;
}
```
Will have its abstract syntax tree modified such that it becomes:
```
function solve() {
  if (true) {
    doThis();
  } 
  
  doThat();
  
  return 1;
}
```
After which, it will be instrumented further, re-generated into something similar to:
```
var coverageReport = {};
coverageReport.statementExecuted = {};

coverageReport.recordExecutedStatement = function (position) {
  coverageReport.statementExecuted[position] = true;
};

function solve() {
  coverageReport.recordExecutedStatement(34);
  if (true) {
    coverageReport.recordExecutedStatement(54);
    doThis();
  }

  coverageReport.recordExecutedStatement(64);
  doThat();

  coverageReport.recordExecutedStatement(83);
  return 1;
}

statementExecutedCount = Object.keys(coverageReport.statementExecuted).length
printReport(statementExecutedCount);
```

This will soon be integrated with our sandboxing module and eventually the entire application. 