### PR TITLE
Add support for the submission, display, and solving of user-submitted problems

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const cookieParser = require('cookie-parser');
 
 app.use(express.text());
 app.use(express.json());
+app.use(express.urlencoded({extended: true}));
 app.use(cookieParser());
 
 /**

--- a/html/partials/submit.hbs
+++ b/html/partials/submit.hbs
@@ -8,7 +8,7 @@
         </button>
       </div>
 
-      <form action="/problems" id="submitProblemForm" method="POST" class="needs-validation" novalidate>
+      <form id="submitProblemForm" method="POST" class="needs-validation" novalidate>
         <div class="modal-body">
             <div class="form-group">
               <label for="title">Problem Title</label>
@@ -23,6 +23,9 @@
             <div class="form-group">
               <label for="code" required>Starter Code</label>
               <textarea class="form-control" id="code" name="code"></textarea>
+              <small id="testsHelp" class="form-text text-muted">
+                Write the name of the function the user should implement.
+              </small>
               <div class="invalid-feedback">
                 Please provide starter code.
               </div>
@@ -31,6 +34,9 @@
             <div class="form-group">
               <label for="tests" required>Tests</label>
               <textarea class="form-control" id="tests" name="tests"></textarea>
+              <small id="testsHelp" class="form-text text-muted">
+                Write assert statements separated by a newline to verify the expected output.
+              </small>
               <div class="invalid-feedback">
                 Please provide tests.
               </div>

--- a/html/partials/submit.hbs
+++ b/html/partials/submit.hbs
@@ -1,0 +1,57 @@
+<div class="modal fade" id="submitProblemModal" tabindex="-1" role="dialog" aria-labelledby="registerLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="submitProblemLabel">Submit a problem</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+      <form action="/problems" id="submitProblemForm" method="POST" class="needs-validation" novalidate>
+        <div class="modal-body">
+            <div class="form-group">
+              <label for="title">Problem Title</label>
+              <input type="text" class="form-control" id="title" name="title" required>
+            </div>
+
+            <div class="form-group">
+              <label for="text">Problem Text</label>
+              <textarea class="form-control" id="text" name="text" required></textarea>
+            </div>
+
+            <div class="form-group">
+              <label for="code" required>Starter Code</label>
+              <textarea class="form-control" id="code" name="code"></textarea>
+              <div class="invalid-feedback">
+                Please provide starter code.
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="tests" required>Tests</label>
+              <textarea class="form-control" id="tests" name="tests"></textarea>
+              <div class="invalid-feedback">
+                Please provide tests.
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="solution" required>Solution</label>
+              <textarea class="form-control" id="solution" name="solution"></textarea>
+              <div class="invalid-feedback">
+                Please provide a solution.
+              </div>
+            </div>
+          </div>
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+            <button type="submit" class="btn btn-primary">Submit</button>
+          </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script src="scripts/submit.js"></script>

--- a/html/problems.hbs
+++ b/html/problems.hbs
@@ -1,5 +1,9 @@
 <div class="container my-5" id="problems-container">
+  {{#if userSubmitted}}
+  <h1>User-Submitted Problems</h1>
+  {{else}}
   <h1>Problems</h1>
+  {{/if}}
 
   {{#each problems}}
   <div class="card mb-3">
@@ -22,5 +26,19 @@
       {{/each}}
     </ul>
   </nav>
+
+  {{>submit}}
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#submitProblemModal">
+    Submit a problem
+  </button>
+  {{#if userSubmitted}}
+  <a href="/problems" class="btn btn-secondary" role="button">
+    View official problems
+  </a>
+  {{else}}
+  <a href="/problems?userSubmitted" class="btn btn-secondary" role="button">
+    View user-submitted problems
+  </a>
+  {{/if}}
 
 </div>

--- a/html/user.hbs
+++ b/html/user.hbs
@@ -8,19 +8,40 @@
   <h1>{{username}}</h1>
   {{#if solutions}}
   <h3>{{username}}'s Solved Problems</h3>
+
   <ul class="list-group my-2">
     {{#each solutions}}
-    <li class="list-group-item">
-      <div class="d-flex justify-content-between">
-        <h5 class="mb-1"><a href="/problems/{{this.problemId}}/solutions">{{this.problemTitle}}</a></h5>
-        <small>{{this.timestamp}}</small>
-      </div>
-      <p class="mb-1">Cyclomatic complexity: {{this.cyclomatic}}</p>
-      <p class="mb-1">Halstead difficulty: {{this.difficulty}}</p>
-      <p class="mb-1">Logical lines of code: {{this.lloc}}</p>
-    </li>
+      {{#unless this.userSubmitted}}
+      <li class="list-group-item">
+        <div class="d-flex justify-content-between">
+          <h5 class="mb-1"><a href="/problems/{{this.problemId}}/solutions">{{this.problemTitle}}</a></h5>
+          <small>{{this.timestamp}}</small>
+        </div>
+        <p class="mb-1">Cyclomatic complexity: {{this.cyclomatic}}</p>
+        <p class="mb-1">Halstead difficulty: {{this.difficulty}}</p>
+        <p class="mb-1">Logical lines of code: {{this.lloc}}</p>
+      </li>
+      {{/unless}}
     {{/each}}
   </ul>
+
+  <ul class="list-group my-2">
+    <h4>Unofficial</h4>
+    {{#each solutions}}
+      {{#if this.userSubmitted}}
+      <li class="list-group-item">
+        <div class="d-flex justify-content-between">
+          <h5 class="mb-1"><a href="/problems/{{this.problemId}}/solutions">{{this.problemTitle}}</a></h5>
+          <small>{{this.timestamp}}</small>
+        </div>
+        <p class="mb-1">Cyclomatic complexity: {{this.cyclomatic}}</p>
+        <p class="mb-1">Halstead difficulty: {{this.difficulty}}</p>
+        <p class="mb-1">Logical lines of code: {{this.lloc}}</p>
+      </li>
+      {{/if}}
+    {{/each}}
+  </ul>
+  
   <p>Share your profile! &#8681</p>
   <div class="a2a_kit a2a_kit_size_32 a2a_default_style">
     <a class="a2a_button_facebook"></a>

--- a/html/user.hbs
+++ b/html/user.hbs
@@ -26,12 +26,11 @@
   </ul>
 
   <ul class="list-group my-2">
-    <h4>Unofficial</h4>
     {{#each solutions}}
       {{#if this.userSubmitted}}
-      <li class="list-group-item">
+      <li class="list-group-item mt-3">
         <div class="d-flex justify-content-between">
-          <h5 class="mb-1"><a href="/problems/{{this.problemId}}/solutions">{{this.problemTitle}}</a></h5>
+          <h5 class="mb-1"><a href="/problems/{{this.problemId}}/solutions">[Unofficial] {{this.problemTitle}}</a></h5>
           <small>{{this.timestamp}}</small>
         </div>
         <p class="mb-1">Cyclomatic complexity: {{this.cyclomatic}}</p>

--- a/modules/problem_util.js
+++ b/modules/problem_util.js
@@ -17,6 +17,7 @@ async function addProblem(problemObject) {
   if (!problemIsValid(problemObject))
     return;
 
+  problemObject.userSubmitted = false;
   const key = await generateKey(problemObject);
   datastore.store(key, problemObject);
 }

--- a/routes/problems.js
+++ b/routes/problems.js
@@ -43,7 +43,7 @@ async function listProblems(listUserSubmitted, pageIndex, pageSize) {
   if (listUserSubmitted) {
     entities = (await datastore.runQuery(query))[0];
     problems = entities.map((entity) => {
-      return new Problem(entity.id, entity.title, entity.text);
+      return new Problem(entity[datastore.KEY].id, entity.title, entity.text);
     });
     return problems;
   } else {

--- a/routes/problems.js
+++ b/routes/problems.js
@@ -1,6 +1,10 @@
 'use strict';
 
+const multer  = require('multer');
+
 const datastore = require('../modules/datastore.js');
+const auth = require('../modules/auth.js');
+const sandbox = require('../modules/code_sandbox_manager.js');
 
 const PROBLEMS_KIND         = 'Problem';
 const DEFAULT_PAGE_SIZE     = 5;
@@ -20,29 +24,68 @@ class Problem {
   }
 }
 
-async function listProblems(pageIndex, pageSize) {
-  const startId = pageSize * (pageIndex - 1);
-  const query = datastore
-    .createQuery(PROBLEMS_KIND)
-    .filter('id', '>', parseInt(startId))
-    .order('id')
-    .limit(parseInt(pageSize));
+/**
+ * Lists problems, filtering on whether they are user-submitted.
+ * Does not limit user-submitted problems for now, as we need to
+ * decide how to approach pagination for user-submitted problems
+ * which do not have an incrementing ID.
+ * @param {boolean} listUserSubmitted
+ * @param {number} pageIndex
+ * @param {number} pageSize
+ */
+async function listProblems(listUserSubmitted, pageIndex, pageSize) {
+  let query = datastore
+      .createQuery(PROBLEMS_KIND)
+      .filter('userSubmitted', '=', listUserSubmitted);
+  let entities = [];
+  let problems = [];
 
-  return (await datastore.runQuery(query))[0];
+  if (listUserSubmitted) {
+    entities = (await datastore.runQuery(query))[0];
+    problems = entities.map((entity) => {
+      return new Problem(entity.id, entity.title, entity.text);
+    });
+    return problems;
+  } else {
+    const startId = pageSize * (pageIndex - 1);
+    query = query
+      .filter('id', '>', parseInt(startId))
+      .order('id')
+      .limit(parseInt(pageSize));
+    entities = (await datastore.runQuery(query))[0];
+    problems = entities.map((entity) => {
+      return new Problem(entity.id, entity.title, entity.text);
+    });
+  }
+  return problems;
 }
 
 
 module.exports = function(app) {
-  app.get('/problems', async function(request, response) {
+  const userSubmitted = async function(request, response, next) {
+    if (Object.keys(request.query).length === 0 || request.query.userSubmitted === undefined) {
+      return next();
+    }
+
+    const problems = await listProblems(true);
+
+    response.render('problems', {
+      problems: problems,
+      userSubmitted: true,
+    });
+  };
+
+  app.get('/problems', userSubmitted, async function(request, response) {
     const clientPageIndex   = parseInt(request.query.pageIndex) || DEFAULT_PAGE_INDEX;
     const clientPageSize    = parseInt(request.query.pageSize) || DEFAULT_PAGE_SIZE;
 
-    const entities = await listProblems(clientPageIndex, clientPageSize);
-    const problems = entities.map((entity) => {
-      return new Problem(entity.id, entity.title, entity.text);
-    });
+    const problems = await listProblems(false, clientPageIndex, clientPageSize);
 
-    const problemsCount     = await datastore.countKind(PROBLEMS_KIND);
+    const problemsCount     = await datastore.countKind(PROBLEMS_KIND, {
+      property: 'userSubmitted',
+      operator: '=',
+      value: false}
+    );
     const pageCount         = Math.ceil(problemsCount / clientPageSize);
     const paginationArray   = Array.from(Array(pageCount), (_, i) => i + 1);
 
@@ -51,6 +94,40 @@ module.exports = function(app) {
       paginationArray: paginationArray,
       currIndex: clientPageIndex
     });
+  });
+
+  app.post('/problems', multer().none(), async function(request, response) {
+    const userResponse = (await auth.getUser(request.cookies.token));
+    if (userResponse === null) {
+      response.status(401).send('Not authenticated. Please log in.');
+      return;
+    }
+
+    const problem = request.body;
+
+    if (!(problem.title && problem.text && problem.code && problem.tests && problem.solution)) {
+      response.status(400).send('Please fill out all fields.');
+      return;
+    }
+
+    const executionResult = await sandbox.run(problem.solution + problem.tests);
+
+    if (executionResult.signal === 'SIGTERM') {
+      response.status(400).send('The code execution timed out.');
+    } else if (executionResult.stderr) {
+      response.status(400).send('Your solution didn\'t pass the test cases.');
+    } else {
+      problem.username = userResponse.user.username;
+      problem.userSubmitted = true;
+      problem.tests = problem.tests.split('\r\n');
+
+      try {
+        await datastore.store(PROBLEMS_KIND, problem);
+        response.sendStatus(200);
+      } catch (error) {
+        response.status(500).send('Something went wrong.');
+      }
+    }
   });
 }
 

--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -13,20 +13,6 @@ const SOLUTION_KIND = 'Solution';
 problemUtil.addFromProblemsDir();
 
 /**
- * Gets problem according to the id given.
- * Utilizes parseInt() as integer sent through request
- * may have its typing wrongly inferred by Node.
- **/
-async function getProblem(id) {
-  const query = datastore
-    .createQuery(PROBLEMS_KIND)
-    .filter('id', '=', parseInt(id));
-
-  const [problems] = await datastore.runQuery(query);
-  return problems[0];
-}
-
-/**
  * Helper function to save submission of solution.
  * Fields in data are not nested to allow easier filtering.
  **/
@@ -50,7 +36,7 @@ module.exports = function(app) {
    * to the problem id given in the request parameter.
    **/
   app.get('/problems/:id', async function(request, response) {
-    const problem = await getProblem(request.params.id);
+    const problem = await datastore.getProblem(request.params.id);
     let dynamicContent = {
       'question-title'  : problem.title,
       'question-text'   : problem.text,
@@ -77,7 +63,7 @@ module.exports = function(app) {
     }
 
     const code      = request.body.code;
-    const problem   = (await getProblem(request.params.id));
+    const problem   = await datastore.getProblem(request.params.id);
     const tests     = problem.tests;
     const timeout   = problem.timeout;
 

--- a/routes/problems_id_solutions.js
+++ b/routes/problems_id_solutions.js
@@ -65,7 +65,7 @@ module.exports = function(app) {
    **/
   app.get('/problems/:id/solutions', async function(request, response) {
     const problemId = request.params.id;
-    const problemTitle = await getProblemTitle(problemId);
+    const problemTitle = (await datastore.getProblem(problemId)).title;
     const rankBy = request.query.rank || DEFAULT_RANK;
 
     const solutions = await listSolutions(problemId, DEFAULT_LIMIT, rankBy, DEFAULT_IS_DESCENDING);

--- a/scripts/submit.js
+++ b/scripts/submit.js
@@ -1,0 +1,57 @@
+const SUBMIT_MODAL_ID = 'submitProblemModal';
+const SUBMIT_FORM_ID = 'submitProblemForm';
+const opts = {
+  mode: 'javascript',
+  lineNumbers: true,
+  autoCloseBrackets: true,
+};
+
+let code;
+let tests;
+let solution;
+let codeAreas;
+
+$(`#${SUBMIT_MODAL_ID}`).on('shown.bs.modal', function(e) {
+  setupCodeAreas();
+  setupValidation(document.getElementById(SUBMIT_FORM_ID));
+});
+
+/**
+ * Converts plain text areas to CodeMirror editors.
+ */
+function setupCodeAreas() {
+  code = CodeMirror.fromTextArea(document.getElementById('code'), opts);
+  tests = CodeMirror.fromTextArea(document.getElementById('tests'), opts);
+  solution = CodeMirror.fromTextArea(document.getElementById('solution'), opts);
+
+  codeAreas = [code, tests, solution];
+}
+
+/**
+ * Adds listener to validate form passed as input.
+ * @param {HTMLFormElement} form
+ */
+function setupValidation(form) {
+  form.addEventListener('submit', function(event) {
+    if (form.checkValidity() === false) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    codeAreas.forEach(validateCodeArea);
+
+    form.classList.add('was-validated');
+  });
+}
+
+/**
+ * Validates that a code area has text and toggles
+ * the .is-invalid class.
+ * @param {CodeMirror} codeArea
+ */
+function validateCodeArea(codeArea) {
+  const textAreaClassList = codeArea.getTextArea().classList;
+  codeArea.getValue() === '' ?
+      textAreaClassList.add('is-invalid') :
+      textAreaClassList.remove('is-invalid');
+}

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -11,3 +11,7 @@ img {
 .modal {
   z-index: 1400;
 }
+
+.form-group .CodeMirror {
+  height: 200px;
+}


### PR DESCRIPTION
*note: has commits from #72 & #74 so that auth works*
This PR adds a post handler to the `/problems` route that validates and stores a user-submitted problem. The GET route is modified to filter the returned problems based on whether the client provides the `?userSubmitted` query string. 
- Note that for now, there is no limit/pagination for user-submitted problems since pagination currently depends on using the `id` property which increments. We'll decide on how to hanlde pagination and limits for user-submitted problems and implement in a future PR.
- Instead, user-submitted problems use the datastore generated ID from their key, so we will have to rely on datastore cursors for pagination.

Also moves `getProblem(id)` to the datastore module. The refactored `getProblem` doesn't require the caller to specify if the problem is user-submitted or not, instead it checks both the `id` property and datastore key for an ID match. We don't have to worry about collisions between the `id` property and key since datastore keys are much larger numbers.

**Screenshots**
[Buttons to add/view user-submitted problems](https://screenshot.googleplex.com/3Gi4V9An3Sk.png)
[Dialog box to submit a problem](https://screenshot.googleplex.com/ifYiuSSHvZc.png)