### PR TITLE
[Pod] Implement call statement removal using AST modification

### DIFF
--- a/modules/code_metrics.js
+++ b/modules/code_metrics.js
@@ -1,5 +1,6 @@
 const escomplex = require('escomplex');
-
+const instrument = require('./instrument_code.js');
+const ASSERT_CALL_NAME = 'assert';
 /**
  * Performs static analysis on code 
  * @param {string} code source code 
@@ -7,6 +8,7 @@ const escomplex = require('escomplex');
  */
 
 function analyze(code) {
+  code = instrument.removeCalls(code, ASSERT_CALL_NAME);
   const result = escomplex.analyse(code);
 
   // Round to 3 decimal places if needed
@@ -17,5 +19,6 @@ function analyze(code) {
     difficulty: roundedDifficulty
   };
 }
+
 
 module.exports = analyze;

--- a/modules/instrument_code.js
+++ b/modules/instrument_code.js
@@ -9,7 +9,7 @@ const estraverse = require('estraverse');
 const escodegen = require('escodegen');
 
 const BLOCK_STATEMENT = 'BlockStatement';
-const IF_STATEMENT = 'IfStatement';
+const EXPRESSION_STATEMENT = 'ExpressionStatement';
 
 const INSTRUMENTATION_HEADER = `
 var coverageReport = {};
@@ -140,10 +140,33 @@ function generateInstrumentedCode(code) {
   };
 }
 
+/**
+ * Utility function that removes all calls from a given piece of code.
+ * For example, given a piece of code:
+ * function hello() {
+ *   toRemove();
+ *   return 1;
+ * }
+ *
+ * toRemove(123); doThis();
+ *
+ * removeCalls, given "toRemove" as a callName
+ * will return a modified code:
+ * function hello() {
+ *   return 1;
+ * }
+ *
+ * doThis();
+ **/
+function removeCalls(code, callName) {
+ return code;
+}
+
 module.exports = {
   wrapInBlockStatement: wrapInBlockStatement,
   addStatementCoverageDetection: addStatementCoverageDetection,
   generateInstrumentedCode: generateInstrumentedCode,
+  removeCalls: removeCalls,
   INSTRUMENTATION_HEADER: INSTRUMENTATION_HEADER,
   INSTRUMENTATION_FOOTER: INSTRUMENTATION_FOOTER,
 };

--- a/modules/instrument_code.js
+++ b/modules/instrument_code.js
@@ -10,6 +10,7 @@ const escodegen = require('escodegen');
 
 const BLOCK_STATEMENT = 'BlockStatement';
 const EXPRESSION_STATEMENT = 'ExpressionStatement';
+const CALL_EXPRESSION = 'CallExpression'
 
 const INSTRUMENTATION_HEADER = `
 var coverageReport = {};
@@ -159,7 +160,20 @@ function generateInstrumentedCode(code) {
  * doThis();
  **/
 function removeCalls(code, callName) {
- return code;
+  let codeAst = acorn.parse(code);
+
+  estraverse.replace(codeAst, {
+    leave: function (node, parent) {
+      if (node.type === EXPRESSION_STATEMENT &&
+          node.expression.type === CALL_EXPRESSION &&
+          node.expression.callee.name === callName) {
+        return acorn.parse('');
+      }
+      return (node);
+    }
+  });
+
+  return escodegen.generate(codeAst);
 }
 
 module.exports = {

--- a/test/instrument_code.test.js
+++ b/test/instrument_code.test.js
@@ -4,6 +4,8 @@ const estraverse = require('estraverse');
 const escodegen = require('escodegen');
 const assert = require('assert');
 
+const CALL_TO_REMOVE = 'toRemove';
+
 /**
 * Helper function to delete all whitespaces in code
 * including space characters, tab spaces, and newlines.
@@ -259,6 +261,56 @@ describe('Code Instrumentation module', () => {
 
       assert.equal(stripSpace(expectedCode), stripSpace(instrumentedCode));
       assert.equal(expectedStatementCount, totalStatementCount);
+    });
+  });
+
+  describe('removeCalls()', () => {
+    it('should remove calls, regardless of its argument', () => {
+      const code = `
+      toRemove();
+      toRemove(1);
+      toRemove(a);
+      toRemove(a, b, {'key': 'value'});
+      `;
+
+      const expectedCode = '';
+      const resultCode = codeInstrumenter.removeCalls(code, CALL_TO_REMOVE);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(resultCode));
+    });
+
+    it('should remove calls, regardless of its scoping', () => {
+      const code = `
+      function scope() {
+        toRemove();
+        return 1;
+      }
+      `;
+
+      const expectedCode = `
+      function scope() {
+        return 1;
+      }
+      `;
+
+      const resultCode = codeInstrumenter.removeCalls(code, CALL_TO_REMOVE);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(resultCode));
+    });
+
+    it('should not be affected by one-liners', () => {
+      const code = `
+        doThis(); toRemove(); doThat();
+      `;
+
+      const expectedCode = `
+        doThis();
+        doThat();
+      `;
+
+      const resultCode = codeInstrumenter.removeCalls(code, CALL_TO_REMOVE);
+
+      assert.equal(stripSpace(expectedCode), stripSpace(resultCode));
     });
   });
 });


### PR DESCRIPTION
This is a collective PR done to give everyone a chance to learn about abstract syntax tree as requested by @chronologos .

This PR implements the functionality to remove arbitrary calls from a piece of code in the code instrumentation module.

In this particular case, we are using it to remove all `assert` call in user submitted code before running static analysis on it to prevent codes to be judged worse in terms of complexity due to rigorous testing.