### PR TITLE
Support pagination of user-submitted problems

### DIFF
--- a/html/problems.hbs
+++ b/html/problems.hbs
@@ -1,10 +1,15 @@
 <div class="container my-5" id="problems-container">
-  {{#if userSubmitted}}
-  <h1>User-Submitted Problems</h1>
-  {{else}}
-  <h1>Problems</h1>
-  {{/if}}
-
+  <h1>{{display}} Problems</h1>
+  <ul class="nav nav-pills my-2">
+    {{#each LIST_OPTIONS}}
+    <li class="nav-item">
+      <a class="nav-link {{#if (eq this.queryString @root.listOption)}}active{{/if}}" 
+          href="/problems?list={{this.queryString}}">
+        {{this.displayString}}
+      </a>
+    </li>
+    {{/each}}
+  </ul>
   {{#each problems}}
   <div class="card mb-3">
     <div class="card-body">
@@ -19,26 +24,24 @@
     <ul class="pagination">
       {{#each paginationArray}}
         {{#if (eq this @root.currIndex)}}
-        <li class="page-item active"><a class="page-link" href="?pageIndex={{this}}">{{this}}</a></li>
+        <li class="page-item active">
+          <a class="page-link" href="?pageIndex={{this}}&list={{@root.listOption}}">
+            {{this}}
+          </a>
+        </li>
         {{else}}
-        <li class="page-item"><a class="page-link" href="?pageIndex={{this}}">{{this}}</a></li>
+        <li class="page-item">
+          <a class="page-link" href="?pageIndex={{this}}&list={{@root.listOption}}">
+            {{this}}
+          </a>
+        </li>
         {{/if}}
       {{/each}}
     </ul>
   </nav>
 
   {{>submit}}
-  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#submitProblemModal">
+  <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#submitProblemModal">
     Submit a problem
   </button>
-  {{#if userSubmitted}}
-  <a href="/problems" class="btn btn-secondary" role="button">
-    View official problems
-  </a>
-  {{else}}
-  <a href="/problems?userSubmitted" class="btn btn-secondary" role="button">
-    View user-submitted problems
-  </a>
-  {{/if}}
-
 </div>

--- a/modules/problem_util.js
+++ b/modules/problem_util.js
@@ -13,34 +13,87 @@ const PROBLEMS_KIND = 'Problem';
  * Asserts that the problem is valid using problemIsValid
  * and guarantees idempotency.
  **/
-async function addProblem(problemObject) {
+async function addProblem(problemObject, filePath) {
   if (!problemIsValid(problemObject))
     return;
 
   problemObject.userSubmitted = false;
-  const key = await generateKey(problemObject);
-  datastore.store(key, problemObject);
+
+  if (problemObject.id == undefined) {
+    await writeId(problemObject, filePath);
+  } else {
+    const key = await getKey(problemObject.id);
+    datastore.store(key, problemObject);
+  }
+}
+
+/**
+ * Writes the next id to problem provided via a YAML file.
+ * Uses a datastore transaction, which uses a reader/writer lock
+ * to enforce serializable isolation (i.e. concurrent writes
+ * will not occur).
+ * @param {Object} problemObject
+ * @param {string} filePath
+ */
+async function writeId(problemObject, filePath) {
+  const transaction = datastore.transaction();
+
+  try {
+    await transaction.run();
+
+    problemObject.id = await getHighestId() + 1;
+    writeYamlFile(filePath, problemObject);
+    problemObject.timestamp = new Date();
+
+    transaction.save({
+      key: datastore.key(PROBLEMS_KIND),
+      data: problemObject
+    });
+    transaction.commit();
+  } catch (error) {
+    console.error(error);
+    transaction.rollback();
+  }
+}
+
+/**
+ * Helper function to get the highest ID in the datastore.
+ * @returns id
+ */
+async function getHighestId() {
+  const query = datastore
+      .createQuery(PROBLEMS_KIND)
+      .order('id', {descending: true})
+      .select('id')
+      .limit(1);
+  const [results] = await datastore.runQuery(query);
+  return results[0].id;
+}
+
+/**
+ * Writes YAML file to the specified file path.
+ * @param {string} filePath
+ * @param {Object} object
+ */
+function writeYamlFile(filePath, object) {
+  const yamlDocument = yaml.safeDump(object);
+  fs.writeFileSync(filePath, yamlDocument);
 }
 
 /**
  * Generates key given a problem object to guarantee idempotency.
  * If a problem with the same id already exists, it will give the
  * entity's key such that it could be updated.
- * Otherwise, PROBLEMS_KIND is simply returned, indicating
- * that a new entity should be created.
  **/
-async function generateKey(problemObject) {
+async function getKey(problemId) {
   const query = datastore
     .createQuery(PROBLEMS_KIND)
-    .filter('id', '=', problemObject.id);
+    .filter('id', '=', problemId)
+    .select('__key__');
 
   const [problems] = await datastore.runQuery(query);
 
-  if (problems.length == 0) {
-    return PROBLEMS_KIND;
-  } else {
-    return problems[0][datastore.KEY];
-  }
+  return problems[0][datastore.KEY];
 }
 
 /**
@@ -49,8 +102,7 @@ async function generateKey(problemObject) {
  * id, title, text, code, tests, and solution.
  **/
 function problemIsValid(problemObject) {
-  return problemObject.hasOwnProperty('id')     && 
-    problemObject.hasOwnProperty('title')       &&
+  return problemObject.hasOwnProperty('title')  &&
     problemObject.hasOwnProperty('text')        &&
     problemObject.hasOwnProperty('code')        &&
     problemObject.hasOwnProperty('tests')       &&
@@ -73,11 +125,11 @@ async function addFromProblemsDir(dirName) {
 
     if (stat.isDirectory()) {
       addFromProblemsDir(fullName);
-    } 
+    }
 
     if (path.extname(fullName) === '.yaml') {
       let problem = readYamlFile(fullName);
-      addProblem(problem);
+      addProblem(problem, fullName);
     }
   });
 }

--- a/routes/problems_id.js
+++ b/routes/problems_id.js
@@ -14,20 +14,6 @@ const CODE_COVERAGE_TIMEOUT_MULTIPLIER = 5;
 problemUtil.addFromProblemsDir();
 
 /**
- * Gets problem according to the id given.
- * Utilizes parseInt() as integer sent through request
- * may have its typing wrongly inferred by Node.
- **/
-async function getProblem(id) {
-  const query = datastore
-    .createQuery(PROBLEMS_KIND)
-    .filter('id', '=', parseInt(id));
-
-  const [problems] = await datastore.runQuery(query);
-  return problems[0];
-}
-
-/**
  * Helper function that calculates code coverage.
  * Multiplies the timeout given by CODE_COVERAGE_TIMEOUT_MULTIPLIER
  * to account for instrumented code taking longer to run

--- a/scripts/submit.js
+++ b/scripts/submit.js
@@ -42,7 +42,7 @@ function setupValidation(form) {
         alert(await response.text());
       } else {
         $(`#${SUBMIT_MODAL_ID}`).modal('hide');
-        window.location = '/problems?userSubmitted';
+        window.location = '/problems?list=user';
       }
     }
 

--- a/scripts/submit.js
+++ b/scripts/submit.js
@@ -11,8 +11,12 @@ let tests;
 let solution;
 let codeAreas;
 
-$(`#${SUBMIT_MODAL_ID}`).on('shown.bs.modal', function(e) {
+// Only set up code areas once to avoid multiple code mirror instances
+$(`#${SUBMIT_MODAL_ID}`).one('shown.bs.modal', function(e) {
   setupCodeAreas();
+});
+
+$(`#${SUBMIT_MODAL_ID}`).on('shown.bs.modal', function(e) {
   setupValidation(SUBMIT_FORM);
 });
 


### PR DESCRIPTION
- This PR allows user-submitted problems to be paginated in a consistent manner with other problems
- Also modifies the problem util to generate the appropriate integer ID, using a datastore transaction to avoid overwrites or other concurrency issues if two problems happen to be created at exactly the same time -- the transaction will block one request until the other is closed
- Users can switch between viewing all problems, official problems, and user-submitted problems


Screenshots:
[Pagination and submit problem button](https://screenshot.googleplex.com/69FWPSkLdRU.png)
[Nav buttons to switch between list options](https://screenshot.googleplex.com/a23o01Dw1Or.png)